### PR TITLE
[STEP06] 장윤경 - 선택 시나리오 (e-commerce)

### DIFF
--- a/src/main/java/kr/hhplus/be/server/coupon/application/port/out/LoadCouponPort.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/application/port/out/LoadCouponPort.java
@@ -13,6 +13,16 @@ public interface LoadCouponPort {
     Optional<CouponInfo> loadCouponById(Long couponId);
     
     /**
+     * 쿠폰 ID로 락을 사용하여 조회 (선착순 쿠폰 발급용)
+     */
+    Optional<CouponInfo> loadCouponByIdWithLock(Long couponId);
+    
+    /**
+     * 쿠폰 발급 수량을 원자적으로 증가 (선착순 처리용)
+     */
+    boolean incrementIssuedCount(Long couponId);
+    
+    /**
      * 쿠폰 정보
      */
     class CouponInfo {

--- a/src/main/java/kr/hhplus/be/server/order/adapter/out/persistence/ProductPersistenceAdapter.java
+++ b/src/main/java/kr/hhplus/be/server/order/adapter/out/persistence/ProductPersistenceAdapter.java
@@ -64,6 +64,18 @@ public class ProductPersistenceAdapter implements LoadProductPort, UpdateProduct
         return true;
     }
 
+    @Override
+    public boolean restoreStock(Long productId, Integer quantity) {
+        ProductData product = products.get(productId);
+        if (product == null) {
+            return false;
+        }
+        
+        // 재고 복구 (차감된 수량만큼 다시 증가)
+        product.setStock(product.getStock() + quantity);
+        return true;
+    }
+
     /**
      * 상품 데이터 내부 클래스
      */

--- a/src/main/java/kr/hhplus/be/server/order/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/kr/hhplus/be/server/order/adapter/out/persistence/UserPersistenceAdapter.java
@@ -6,7 +6,6 @@ import kr.hhplus.be.server.order.application.port.out.LoadUserPort;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * 사용자 영속성 Adapter (Outgoing)
@@ -15,7 +14,6 @@ import java.util.concurrent.atomic.AtomicLong;
 public class UserPersistenceAdapter implements LoadUserPort {
 
     private final Map<Long, Object> users = new ConcurrentHashMap<>();
-    private final AtomicLong idGenerator = new AtomicLong(1);
 
     public UserPersistenceAdapter() {
         // 더미 데이터 초기화

--- a/src/main/java/kr/hhplus/be/server/order/application/port/out/UpdateProductStockPort.java
+++ b/src/main/java/kr/hhplus/be/server/order/application/port/out/UpdateProductStockPort.java
@@ -9,4 +9,9 @@ public interface UpdateProductStockPort {
      * 상품 재고 차감
      */
     boolean deductStock(Long productId, Integer quantity);
+    
+    /**
+     * 상품 재고 복구 (차감된 수량만큼 다시 증가)
+     */
+    boolean restoreStock(Long productId, Integer quantity);
 } 

--- a/src/test/java/kr/hhplus/be/server/coupon/adapter/out/persistence/CouponPersistenceAdapterTest.java
+++ b/src/test/java/kr/hhplus/be/server/coupon/adapter/out/persistence/CouponPersistenceAdapterTest.java
@@ -1,0 +1,275 @@
+package kr.hhplus.be.server.coupon.adapter.out.persistence;
+
+import kr.hhplus.be.server.coupon.application.port.out.LoadCouponPort;
+import kr.hhplus.be.server.coupon.application.port.out.SaveCouponPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CouponPersistenceAdapterTest {
+
+    private CouponPersistenceAdapter couponPersistenceAdapter;
+
+    @BeforeEach
+    void setUp() {
+        couponPersistenceAdapter = new CouponPersistenceAdapter();
+    }
+
+    @Test
+    @DisplayName("쿠폰 조회 - 정상 조회")
+    void loadCouponById_Success() {
+        // given
+        Long couponId = 1L;
+
+        // when
+        Optional<LoadCouponPort.CouponInfo> result = couponPersistenceAdapter.loadCouponById(couponId);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(couponId);
+        assertThat(result.get().getName()).isEqualTo("쿠폰 1");
+        assertThat(result.get().getDiscountAmount()).isEqualTo(1000);
+        assertThat(result.get().getMaxIssuanceCount()).isEqualTo(100);
+        assertThat(result.get().getIssuedCount()).isEqualTo(0);
+        assertThat(result.get().getStatus()).isEqualTo("ACTIVE");
+    }
+
+    @Test
+    @DisplayName("쿠폰 조회 - 존재하지 않는 쿠폰")
+    void loadCouponById_NotFound() {
+        // given
+        Long couponId = 999L;
+
+        // when
+        Optional<LoadCouponPort.CouponInfo> result = couponPersistenceAdapter.loadCouponById(couponId);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("락을 사용한 쿠폰 조회 - 정상 조회")
+    void loadCouponByIdWithLock_Success() {
+        // given
+        Long couponId = 1L;
+
+        // when
+        Optional<LoadCouponPort.CouponInfo> result = couponPersistenceAdapter.loadCouponByIdWithLock(couponId);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(couponId);
+        assertThat(result.get().getName()).isEqualTo("쿠폰 1");
+        assertThat(result.get().getDiscountAmount()).isEqualTo(1000);
+        assertThat(result.get().getMaxIssuanceCount()).isEqualTo(100);
+        assertThat(result.get().getIssuedCount()).isEqualTo(0);
+        assertThat(result.get().getStatus()).isEqualTo("ACTIVE");
+    }
+
+    @Test
+    @DisplayName("락을 사용한 쿠폰 조회 - 존재하지 않는 쿠폰")
+    void loadCouponByIdWithLock_NotFound() {
+        // given
+        Long couponId = 999L;
+
+        // when
+        Optional<LoadCouponPort.CouponInfo> result = couponPersistenceAdapter.loadCouponByIdWithLock(couponId);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 수량 증가 - 정상 증가")
+    void incrementIssuedCount_Success() {
+        // given
+        Long couponId = 1L;
+
+        // when
+        boolean result = couponPersistenceAdapter.incrementIssuedCount(couponId);
+
+        // then
+        assertThat(result).isTrue();
+        
+        // 발급 수량이 증가했는지 확인
+        Optional<LoadCouponPort.CouponInfo> couponInfo = couponPersistenceAdapter.loadCouponById(couponId);
+        assertThat(couponInfo).isPresent();
+        assertThat(couponInfo.get().getIssuedCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 수량 증가 - 최대 수량 도달")
+    void incrementIssuedCount_MaxCountReached() {
+        // given
+        Long couponId = 1L;
+        
+        // 최대 발급 수량까지 증가
+        for (int i = 0; i < 100; i++) {
+            couponPersistenceAdapter.incrementIssuedCount(couponId);
+        }
+
+        // when
+        boolean result = couponPersistenceAdapter.incrementIssuedCount(couponId);
+
+        // then
+        assertThat(result).isFalse();
+        
+        // 상태가 SOLD_OUT로 변경되었는지 확인
+        Optional<LoadCouponPort.CouponInfo> couponInfo = couponPersistenceAdapter.loadCouponById(couponId);
+        assertThat(couponInfo).isPresent();
+        assertThat(couponInfo.get().getStatus()).isEqualTo("SOLD_OUT");
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 수량 증가 - 존재하지 않는 쿠폰")
+    void incrementIssuedCount_CouponNotFound() {
+        // given
+        Long couponId = 999L;
+
+        // when
+        boolean result = couponPersistenceAdapter.incrementIssuedCount(couponId);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("선착순 쿠폰 발급 - 동시 요청 처리")
+    void incrementIssuedCount_ConcurrentRequests_FirstComeFirstServed() throws InterruptedException {
+        // given
+        Long couponId = 999L; // 테스트용 쿠폰 ID
+        int threadCount = 10;
+        int maxIssuanceCount = 5; // 최대 5개만 발급 가능
+        
+        // 테스트용 쿠폰 생성
+        SaveCouponPort.CouponInfo testCoupon = new SaveCouponPort.CouponInfo(
+                couponId, "테스트 쿠폰", "테스트 쿠폰 설명", 1000, maxIssuanceCount, 0, "ACTIVE");
+        couponPersistenceAdapter.saveCoupon(testCoupon);
+        
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    boolean result = couponPersistenceAdapter.incrementIssuedCount(couponId);
+                    if (result) {
+                        successCount.incrementAndGet();
+                    } else {
+                        failureCount.incrementAndGet();
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        
+        latch.await();
+        executor.shutdown();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(maxIssuanceCount);
+        assertThat(failureCount.get()).isEqualTo(threadCount - maxIssuanceCount);
+        
+        // 추가 호출 시 실패하는지 확인
+        assertThat(couponPersistenceAdapter.incrementIssuedCount(couponId)).isFalse();
+        
+        // 상태가 SOLD_OUT로 변경되었는지 확인
+        Optional<LoadCouponPort.CouponInfo> couponInfo = couponPersistenceAdapter.loadCouponById(couponId);
+        assertThat(couponInfo).isPresent();
+        assertThat(couponInfo.get().getStatus()).isEqualTo("SOLD_OUT");
+        assertThat(couponInfo.get().getIssuedCount()).isEqualTo(maxIssuanceCount);
+    }
+
+    @Test
+    @DisplayName("선착순 쿠폰 발급 - 여러 쿠폰 동시 처리")
+    void incrementIssuedCount_MultipleCoupons_Independent() throws InterruptedException {
+        // given
+        Long couponId1 = 1L;
+        Long couponId2 = 2L;
+        int threadCount = 5;
+        
+        CountDownLatch latch = new CountDownLatch(threadCount * 2);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount * 2);
+        AtomicInteger successCount1 = new AtomicInteger(0);
+        AtomicInteger successCount2 = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            // 쿠폰 1 발급 시도
+            executor.submit(() -> {
+                try {
+                    if (couponPersistenceAdapter.incrementIssuedCount(couponId1)) {
+                        successCount1.incrementAndGet();
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+            
+            // 쿠폰 2 발급 시도
+            executor.submit(() -> {
+                try {
+                    if (couponPersistenceAdapter.incrementIssuedCount(couponId2)) {
+                        successCount2.incrementAndGet();
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        
+        latch.await();
+        executor.shutdown();
+
+        // then
+        // 각 쿠폰은 독립적으로 처리되어야 함
+        assertThat(successCount1.get()).isEqualTo(threadCount); // 쿠폰 1은 모두 성공
+        assertThat(successCount2.get()).isEqualTo(threadCount); // 쿠폰 2도 모두 성공
+        
+        // 각 쿠폰의 발급 수량 확인
+        Optional<LoadCouponPort.CouponInfo> couponInfo1 = couponPersistenceAdapter.loadCouponById(couponId1);
+        Optional<LoadCouponPort.CouponInfo> couponInfo2 = couponPersistenceAdapter.loadCouponById(couponId2);
+        
+        assertThat(couponInfo1).isPresent();
+        assertThat(couponInfo1.get().getIssuedCount()).isEqualTo(threadCount);
+        
+        assertThat(couponInfo2).isPresent();
+        assertThat(couponInfo2.get().getIssuedCount()).isEqualTo(threadCount);
+    }
+
+    @Test
+    @DisplayName("쿠폰 저장 - 정상 저장")
+    void saveCoupon_Success() {
+        // given
+        SaveCouponPort.CouponInfo couponInfo = new SaveCouponPort.CouponInfo(
+                999L, "새 쿠폰", "새 쿠폰 설명", 2000, 50, 10, "ACTIVE");
+
+        // when
+        SaveCouponPort.CouponInfo savedCoupon = couponPersistenceAdapter.saveCoupon(couponInfo);
+
+        // then
+        assertThat(savedCoupon.getId()).isEqualTo(999L);
+        assertThat(savedCoupon.getName()).isEqualTo("새 쿠폰");
+        assertThat(savedCoupon.getDiscountAmount()).isEqualTo(2000);
+        assertThat(savedCoupon.getMaxIssuanceCount()).isEqualTo(50);
+        assertThat(savedCoupon.getIssuedCount()).isEqualTo(10);
+        assertThat(savedCoupon.getStatus()).isEqualTo("ACTIVE");
+        
+        // 저장된 쿠폰이 조회되는지 확인
+        Optional<LoadCouponPort.CouponInfo> foundCoupon = couponPersistenceAdapter.loadCouponById(999L);
+        assertThat(foundCoupon).isPresent();
+        assertThat(foundCoupon.get().getName()).isEqualTo("새 쿠폰");
+    }
+} 

--- a/src/test/java/kr/hhplus/be/server/coupon/application/facade/CouponFacadeTest.java
+++ b/src/test/java/kr/hhplus/be/server/coupon/application/facade/CouponFacadeTest.java
@@ -21,9 +21,15 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,273 +57,257 @@ class CouponFacadeTest {
 
     @BeforeEach
     void setUp() {
-        couponFacade = new CouponFacade(loadUserPort, loadCouponPort, saveCouponPort,
-                loadUserCouponPort, saveUserCouponPort, updateUserCouponPort);
+        couponFacade = new CouponFacade(
+                loadUserPort,
+                loadCouponPort,
+                saveCouponPort,
+                loadUserCouponPort,
+                saveUserCouponPort,
+                updateUserCouponPort
+        );
     }
 
     @Test
-    @DisplayName("쿠폰 발급 성공")
-    void issueCoupon_Success() {
+    @DisplayName("선착순 쿠폰 발급 - 정상 발급")
+    void issueCoupon_FirstComeFirstServed_Success() {
         // given
         Long userId = 1L;
         Long couponId = 1L;
-        Integer discountAmount = 1000;
-        
-        IssueCouponUseCase.IssueCouponCommand command = 
-            new IssueCouponUseCase.IssueCouponCommand(userId, couponId);
-        
-        LoadCouponPort.CouponInfo couponInfo = new LoadCouponPort.CouponInfo(
-                couponId, "테스트 쿠폰", "테스트 쿠폰 설명", discountAmount, 100, 50, "ACTIVE");
-        
-        UserCoupon userCoupon = new UserCoupon(userId, couponId, discountAmount);
-        userCoupon.setId(1L);
-        userCoupon.setStatus(UserCoupon.UserCouponStatus.AVAILABLE);
         
         when(loadUserPort.existsById(userId)).thenReturn(true);
-        when(loadCouponPort.loadCouponById(couponId)).thenReturn(Optional.of(couponInfo));
-        when(saveCouponPort.saveCoupon(any(SaveCouponPort.CouponInfo.class))).thenReturn(
-            new SaveCouponPort.CouponInfo(couponId, "테스트 쿠폰", "테스트 쿠폰 설명", 
-                discountAmount, 100, 51, "ACTIVE"));
-        when(saveUserCouponPort.saveUserCoupon(any(UserCoupon.class))).thenReturn(userCoupon);
+        when(loadCouponPort.loadCouponByIdWithLock(couponId))
+                .thenReturn(Optional.of(new LoadCouponPort.CouponInfo(
+                        couponId, "테스트 쿠폰", "테스트 쿠폰 설명", 
+                        1000, 10, 5, "ACTIVE")));
+        when(loadCouponPort.incrementIssuedCount(couponId)).thenReturn(true);
+        when(saveUserCouponPort.saveUserCoupon(any(UserCoupon.class)))
+                .thenAnswer(invocation -> {
+                    UserCoupon userCoupon = invocation.getArgument(0);
+                    userCoupon.setId(1L);
+                    return userCoupon;
+                });
 
         // when
-        IssueCouponUseCase.IssueCouponResult result = couponFacade.issueCoupon(command);
+        var result = couponFacade.issueCoupon(
+                new IssueCouponUseCase.IssueCouponCommand(userId, couponId)
+        );
 
         // then
         assertThat(result.isSuccess()).isTrue();
         assertThat(result.getUserCouponId()).isEqualTo(1L);
         assertThat(result.getCouponId()).isEqualTo(couponId);
         assertThat(result.getCouponName()).isEqualTo("테스트 쿠폰");
-        assertThat(result.getDiscountAmount()).isEqualTo(discountAmount);
+        assertThat(result.getDiscountAmount()).isEqualTo(1000);
         assertThat(result.getStatus()).isEqualTo("AVAILABLE");
-        assertThat(result.getErrorMessage()).isNull();
         
-        verify(loadUserPort).existsById(userId);
-        verify(loadCouponPort).loadCouponById(couponId);
-        verify(saveCouponPort).saveCoupon(any(SaveCouponPort.CouponInfo.class));
-        verify(saveUserCouponPort).saveUserCoupon(any(UserCoupon.class));
+        verify(loadCouponPort).loadCouponByIdWithLock(couponId);
+        verify(loadCouponPort).incrementIssuedCount(couponId);
     }
 
     @Test
-    @DisplayName("쿠폰 발급 실패 - 사용자가 존재하지 않는 경우")
-    void issueCoupon_Failure_UserNotFound() {
+    @DisplayName("선착순 쿠폰 발급 - 재고 소진으로 실패")
+    void issueCoupon_OutOfStock_Failure() {
         // given
-        Long userId = 999L;
+        Long userId = 1L;
         Long couponId = 1L;
         
-        IssueCouponUseCase.IssueCouponCommand command = 
-            new IssueCouponUseCase.IssueCouponCommand(userId, couponId);
-        
-        when(loadUserPort.existsById(userId)).thenReturn(false);
+        when(loadUserPort.existsById(userId)).thenReturn(true);
+        when(loadCouponPort.loadCouponByIdWithLock(couponId))
+                .thenReturn(Optional.of(new LoadCouponPort.CouponInfo(
+                        couponId, "테스트 쿠폰", "테스트 쿠폰 설명", 
+                        1000, 10, 10, "ACTIVE"))); // 이미 최대 발급 수량에 도달
+        when(loadCouponPort.incrementIssuedCount(couponId)).thenReturn(false);
 
         // when
-        IssueCouponUseCase.IssueCouponResult result = couponFacade.issueCoupon(command);
+        var result = couponFacade.issueCoupon(
+                new IssueCouponUseCase.IssueCouponCommand(userId, couponId)
+        );
 
         // then
         assertThat(result.isSuccess()).isFalse();
-        assertThat(result.getErrorMessage()).isEqualTo("사용자를 찾을 수 없습니다.");
+        assertThat(result.getErrorMessage()).contains("쿠폰이 모두 소진되었습니다");
         
-        verify(loadUserPort).existsById(userId);
-        verify(loadCouponPort, never()).loadCouponById(any());
-        verify(saveCouponPort, never()).saveCoupon(any());
+        verify(loadCouponPort).loadCouponByIdWithLock(couponId);
+        verify(loadCouponPort).incrementIssuedCount(couponId);
         verify(saveUserCouponPort, never()).saveUserCoupon(any());
     }
 
     @Test
-    @DisplayName("쿠폰 발급 실패 - 쿠폰이 존재하지 않는 경우")
-    void issueCoupon_Failure_CouponNotFound() {
+    @DisplayName("선착순 쿠폰 발급 - 동시 요청 처리")
+    void issueCoupon_ConcurrentRequests_FirstComeFirstServed() throws InterruptedException {
+        // given
+        Long userId = 1L;
+        Long couponId = 1L;
+        int threadCount = 5;
+        int maxIssuanceCount = 3; // 최대 3개만 발급 가능
+        
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+        
+        // Mock 설정
+        when(loadUserPort.existsById(userId)).thenReturn(true);
+        when(loadCouponPort.loadCouponByIdWithLock(couponId))
+                .thenReturn(Optional.of(new LoadCouponPort.CouponInfo(
+                        couponId, "테스트 쿠폰", "테스트 쿠폰 설명", 
+                        1000, maxIssuanceCount, 0, "ACTIVE")));
+        
+        // incrementIssuedCount를 호출할 때마다 다른 결과 반환 (선착순 시뮬레이션)
+        AtomicInteger callCount = new AtomicInteger(0);
+        when(loadCouponPort.incrementIssuedCount(couponId))
+                .thenAnswer(invocation -> {
+                    int currentCall = callCount.incrementAndGet();
+                    return currentCall <= maxIssuanceCount; // 처음 3번만 성공
+                });
+        
+        when(saveUserCouponPort.saveUserCoupon(any(UserCoupon.class)))
+                .thenAnswer(invocation -> {
+                    UserCoupon userCoupon = invocation.getArgument(0);
+                    userCoupon.setId(successCount.get() + 1L);
+                    return userCoupon;
+                });
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    var result = couponFacade.issueCoupon(
+                            new IssueCouponUseCase.IssueCouponCommand(userId, couponId)
+                    );
+                    
+                    if (result.isSuccess()) {
+                        successCount.incrementAndGet();
+                    } else {
+                        failureCount.incrementAndGet();
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        
+        latch.await();
+        executor.shutdown();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(maxIssuanceCount);
+        assertThat(failureCount.get()).isEqualTo(threadCount - maxIssuanceCount);
+        assertThat(loadCouponPort.incrementIssuedCount(couponId)).isFalse(); // 추가 호출 시 실패
+    }
+
+    @Test
+    @DisplayName("선착순 쿠폰 발급 - 잘못된 사용자 ID")
+    void issueCoupon_InvalidUserId_Failure() {
+        // given
+        Long userId = -1L;
+        Long couponId = 1L;
+
+        // when
+        var result = couponFacade.issueCoupon(
+                new IssueCouponUseCase.IssueCouponCommand(userId, couponId)
+        );
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrorMessage()).contains("잘못된 사용자 ID");
+        
+        verify(loadUserPort, never()).existsById(anyLong());
+        verify(loadCouponPort, never()).loadCouponByIdWithLock(anyLong());
+    }
+
+    @Test
+    @DisplayName("선착순 쿠폰 발급 - 존재하지 않는 사용자")
+    void issueCoupon_UserNotFound_Failure() {
+        // given
+        Long userId = 1L;
+        Long couponId = 1L;
+        
+        when(loadUserPort.existsById(userId)).thenReturn(false);
+
+        // when
+        var result = couponFacade.issueCoupon(
+                new IssueCouponUseCase.IssueCouponCommand(userId, couponId)
+        );
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrorMessage()).contains("사용자를 찾을 수 없습니다");
+        
+        verify(loadUserPort).existsById(userId);
+        verify(loadCouponPort, never()).loadCouponByIdWithLock(anyLong());
+    }
+
+    @Test
+    @DisplayName("선착순 쿠폰 발급 - 존재하지 않는 쿠폰")
+    void issueCoupon_CouponNotFound_Failure() {
         // given
         Long userId = 1L;
         Long couponId = 999L;
         
-        IssueCouponUseCase.IssueCouponCommand command = 
-            new IssueCouponUseCase.IssueCouponCommand(userId, couponId);
-        
         when(loadUserPort.existsById(userId)).thenReturn(true);
-        when(loadCouponPort.loadCouponById(couponId)).thenReturn(Optional.empty());
+        when(loadCouponPort.loadCouponByIdWithLock(couponId)).thenReturn(Optional.empty());
 
         // when
-        IssueCouponUseCase.IssueCouponResult result = couponFacade.issueCoupon(command);
+        var result = couponFacade.issueCoupon(
+                new IssueCouponUseCase.IssueCouponCommand(userId, couponId)
+        );
 
         // then
         assertThat(result.isSuccess()).isFalse();
-        assertThat(result.getErrorMessage()).isEqualTo("존재하지 않는 쿠폰입니다.");
+        assertThat(result.getErrorMessage()).contains("존재하지 않는 쿠폰입니다");
         
         verify(loadUserPort).existsById(userId);
-        verify(loadCouponPort).loadCouponById(couponId);
-        verify(saveCouponPort, never()).saveCoupon(any());
-        verify(saveUserCouponPort, never()).saveUserCoupon(any());
+        verify(loadCouponPort).loadCouponByIdWithLock(couponId);
+        verify(loadCouponPort, never()).incrementIssuedCount(anyLong());
     }
 
     @Test
-    @DisplayName("쿠폰 발급 실패 - 발급할 수 없는 쿠폰인 경우")
-    void issueCoupon_Failure_CannotIssueCoupon() {
+    @DisplayName("선착순 쿠폰 발급 - 비활성 쿠폰")
+    void issueCoupon_InactiveCoupon_Failure() {
         // given
         Long userId = 1L;
         Long couponId = 1L;
         
-        IssueCouponUseCase.IssueCouponCommand command = 
-            new IssueCouponUseCase.IssueCouponCommand(userId, couponId);
+        when(loadUserPort.existsById(userId)).thenReturn(true);
+        when(loadCouponPort.loadCouponByIdWithLock(couponId))
+                .thenReturn(Optional.of(new LoadCouponPort.CouponInfo(
+                        couponId, "테스트 쿠폰", "테스트 쿠폰 설명", 
+                        1000, 10, 5, "INACTIVE"))); // 비활성 상태
+
+        // when
+        var result = couponFacade.issueCoupon(
+                new IssueCouponUseCase.IssueCouponCommand(userId, couponId)
+        );
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrorMessage()).contains("발급할 수 없는 쿠폰입니다");
         
-        LoadCouponPort.CouponInfo couponInfo = new LoadCouponPort.CouponInfo(
-                couponId, "테스트 쿠폰", "테스트 쿠폰 설명", 1000, 100, 100, "SOLD_OUT");
+        verify(loadUserPort).existsById(userId);
+        verify(loadCouponPort).loadCouponByIdWithLock(couponId);
+        verify(loadCouponPort, never()).incrementIssuedCount(anyLong());
+    }
+
+    @Test
+    @DisplayName("선착순 쿠폰 발급 - 예외 발생 시 처리")
+    void issueCoupon_ExceptionOccurs_Failure() {
+        // given
+        Long userId = 1L;
+        Long couponId = 1L;
         
         when(loadUserPort.existsById(userId)).thenReturn(true);
-        when(loadCouponPort.loadCouponById(couponId)).thenReturn(Optional.of(couponInfo));
+        when(loadCouponPort.loadCouponByIdWithLock(couponId))
+                .thenThrow(new RuntimeException("데이터베이스 연결 오류"));
 
         // when
-        IssueCouponUseCase.IssueCouponResult result = couponFacade.issueCoupon(command);
+        var result = couponFacade.issueCoupon(
+                new IssueCouponUseCase.IssueCouponCommand(userId, couponId)
+        );
 
         // then
         assertThat(result.isSuccess()).isFalse();
-        assertThat(result.getErrorMessage()).isEqualTo("발급할 수 없는 쿠폰입니다.");
-        
-        verify(loadUserPort).existsById(userId);
-        verify(loadCouponPort).loadCouponById(couponId);
-        verify(saveCouponPort, never()).saveCoupon(any());
-        verify(saveUserCouponPort, never()).saveUserCoupon(any());
-    }
-
-    @Test
-    @DisplayName("사용자 쿠폰 조회 성공")
-    void getUserCoupons_Success() {
-        // given
-        Long userId = 1L;
-        
-        GetUserCouponsUseCase.GetUserCouponsCommand command = 
-            new GetUserCouponsUseCase.GetUserCouponsCommand(userId);
-        
-        LoadUserCouponPort.UserCouponInfo userCouponInfo = new LoadUserCouponPort.UserCouponInfo(
-                1L, userId, 1L, "AVAILABLE", "2024-01-01T10:00:00", null, null);
-        
-        LoadCouponPort.CouponInfo couponInfo = new LoadCouponPort.CouponInfo(
-                1L, "테스트 쿠폰", "테스트 쿠폰 설명", 1000, 100, 50, "ACTIVE");
-        
-        when(loadUserPort.existsById(userId)).thenReturn(true);
-        when(loadUserCouponPort.loadUserCouponsByUserId(userId)).thenReturn(List.of(userCouponInfo));
-        when(loadCouponPort.loadCouponById(1L)).thenReturn(Optional.of(couponInfo));
-
-        // when
-        GetUserCouponsUseCase.GetUserCouponsResult result = couponFacade.getUserCoupons(command);
-
-        // then
-        assertThat(result.getUserCoupons()).hasSize(1);
-        assertThat(result.getUserCoupons().get(0).getUserCouponId()).isEqualTo(1L);
-        assertThat(result.getUserCoupons().get(0).getCouponId()).isEqualTo(1L);
-        assertThat(result.getUserCoupons().get(0).getCouponName()).isEqualTo("테스트 쿠폰");
-        assertThat(result.getUserCoupons().get(0).getDiscountAmount()).isEqualTo(1000);
-        assertThat(result.getUserCoupons().get(0).getStatus()).isEqualTo("AVAILABLE");
-        
-        verify(loadUserPort).existsById(userId);
-        verify(loadUserCouponPort).loadUserCouponsByUserId(userId);
-        verify(loadCouponPort).loadCouponById(1L);
-    }
-
-    @Test
-    @DisplayName("사용자 쿠폰 조회 실패 - 사용자가 존재하지 않는 경우")
-    void getUserCoupons_Failure_UserNotFound() {
-        // given
-        Long userId = 999L;
-        
-        GetUserCouponsUseCase.GetUserCouponsCommand command = 
-            new GetUserCouponsUseCase.GetUserCouponsCommand(userId);
-        
-        when(loadUserPort.existsById(userId)).thenReturn(false);
-
-        // when
-        GetUserCouponsUseCase.GetUserCouponsResult result = couponFacade.getUserCoupons(command);
-
-        // then
-        assertThat(result.getUserCoupons()).isEmpty();
-        
-        verify(loadUserPort).existsById(userId);
-        verify(loadUserCouponPort, never()).loadUserCouponsByUserId(any());
-    }
-
-    @Test
-    @DisplayName("쿠폰 사용 성공")
-    void useCoupon_Success() {
-        // given
-        Long userId = 1L;
-        Long userCouponId = 1L;
-        BigDecimal orderAmount = new BigDecimal("5000");
-        Integer discountAmount = 1000;
-        
-        UseCouponUseCase.UseCouponCommand command = 
-            new UseCouponUseCase.UseCouponCommand(userId, userCouponId, orderAmount);
-        
-        UserCoupon userCoupon = new UserCoupon(userId, 1L, discountAmount);
-        userCoupon.setId(userCouponId);
-        userCoupon.setStatus(UserCoupon.UserCouponStatus.AVAILABLE);
-        
-        when(loadUserCouponPort.loadUserCoupon(userCouponId)).thenReturn(Optional.of(userCoupon));
-        doNothing().when(updateUserCouponPort).updateUserCoupon(any(UserCoupon.class));
-
-        // when
-        UseCouponUseCase.UseCouponResult result = couponFacade.useCoupon(command);
-
-        // then
-        assertThat(result.isSuccess()).isTrue();
-        assertThat(result.getDiscountedAmount()).isEqualTo(new BigDecimal("4000"));
-        assertThat(result.getDiscountAmount()).isEqualTo(discountAmount);
-        assertThat(result.getErrorMessage()).isNull();
-        
-        verify(loadUserCouponPort).loadUserCoupon(userCouponId);
-        verify(updateUserCouponPort).updateUserCoupon(any(UserCoupon.class));
-    }
-
-    @Test
-    @DisplayName("쿠폰 사용 실패 - 쿠폰을 찾을 수 없는 경우")
-    void useCoupon_Failure_CouponNotFound() {
-        // given
-        Long userId = 1L;
-        Long userCouponId = 999L;
-        BigDecimal orderAmount = new BigDecimal("5000");
-        
-        UseCouponUseCase.UseCouponCommand command = 
-            new UseCouponUseCase.UseCouponCommand(userId, userCouponId, orderAmount);
-        
-        when(loadUserCouponPort.loadUserCoupon(userCouponId)).thenReturn(Optional.empty());
-
-        // when
-        UseCouponUseCase.UseCouponResult result = couponFacade.useCoupon(command);
-
-        // then
-        assertThat(result.isSuccess()).isFalse();
-        assertThat(result.getErrorMessage()).isEqualTo("쿠폰을 찾을 수 없습니다.");
-        assertThat(result.getDiscountedAmount()).isNull();
-        assertThat(result.getDiscountAmount()).isNull();
-        
-        verify(loadUserCouponPort).loadUserCoupon(userCouponId);
-        verify(updateUserCouponPort, never()).updateUserCoupon(any());
-    }
-
-    @Test
-    @DisplayName("쿠폰 사용 실패 - 쿠폰 소유자가 아닌 경우")
-    void useCoupon_Failure_NotOwner() {
-        // given
-        Long userId = 1L;
-        Long userCouponId = 1L;
-        Long actualOwnerId = 2L;
-        BigDecimal orderAmount = new BigDecimal("5000");
-        
-        UseCouponUseCase.UseCouponCommand command = 
-            new UseCouponUseCase.UseCouponCommand(userId, userCouponId, orderAmount);
-        
-        UserCoupon userCoupon = new UserCoupon(actualOwnerId, 1L, 1000);
-        userCoupon.setId(userCouponId);
-        userCoupon.setStatus(UserCoupon.UserCouponStatus.AVAILABLE);
-        
-        when(loadUserCouponPort.loadUserCoupon(userCouponId)).thenReturn(Optional.of(userCoupon));
-
-        // when
-        UseCouponUseCase.UseCouponResult result = couponFacade.useCoupon(command);
-
-        // then
-        assertThat(result.isSuccess()).isFalse();
-        assertThat(result.getErrorMessage()).isEqualTo("해당 쿠폰의 소유자가 아닙니다.");
-        
-        verify(loadUserCouponPort).loadUserCoupon(userCouponId);
-        verify(updateUserCouponPort, never()).updateUserCoupon(any());
+        assertThat(result.getErrorMessage()).contains("쿠폰 발급 중 오류가 발생했습니다");
+        assertThat(result.getErrorMessage()).contains("데이터베이스 연결 오류");
     }
 } 

--- a/src/test/java/kr/hhplus/be/server/order/adapter/out/persistence/ProductPersistenceAdapterTest.java
+++ b/src/test/java/kr/hhplus/be/server/order/adapter/out/persistence/ProductPersistenceAdapterTest.java
@@ -1,0 +1,266 @@
+package kr.hhplus.be.server.order.adapter.out.persistence;
+
+import kr.hhplus.be.server.order.application.port.out.LoadProductPort;
+import kr.hhplus.be.server.order.application.port.out.UpdateProductStockPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProductPersistenceAdapterTest {
+
+    private ProductPersistenceAdapter productPersistenceAdapter;
+
+    @BeforeEach
+    void setUp() {
+        productPersistenceAdapter = new ProductPersistenceAdapter();
+    }
+
+    @Test
+    @DisplayName("상품 조회 - 정상 조회")
+    void loadProductById_Success() {
+        // given
+        Long productId = 1L;
+
+        // when
+        Optional<LoadProductPort.ProductInfo> result = productPersistenceAdapter.loadProductById(productId);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(productId);
+        assertThat(result.get().getName()).isEqualTo("상품 1");
+        assertThat(result.get().getCurrentPrice()).isEqualTo(BigDecimal.valueOf(11000));
+        assertThat(result.get().getStock()).isEqualTo(100);
+    }
+
+    @Test
+    @DisplayName("상품 조회 - 존재하지 않는 상품")
+    void loadProductById_NotFound() {
+        // given
+        Long productId = 999L;
+
+        // when
+        Optional<LoadProductPort.ProductInfo> result = productPersistenceAdapter.loadProductById(productId);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("재고 차감 - 정상 차감")
+    void deductStock_Success() {
+        // given
+        Long productId = 1L;
+        Integer quantity = 10;
+
+        // when
+        boolean result = productPersistenceAdapter.deductStock(productId, quantity);
+
+        // then
+        assertThat(result).isTrue();
+        
+        // 재고가 실제로 차감되었는지 확인
+        Optional<LoadProductPort.ProductInfo> productInfo = productPersistenceAdapter.loadProductById(productId);
+        assertThat(productInfo).isPresent();
+        assertThat(productInfo.get().getStock()).isEqualTo(90); // 100 - 10
+    }
+
+    @Test
+    @DisplayName("재고 차감 - 재고 부족")
+    void deductStock_InsufficientStock() {
+        // given
+        Long productId = 1L;
+        Integer quantity = 150; // 재고(100)보다 많은 수량
+
+        // when
+        boolean result = productPersistenceAdapter.deductStock(productId, quantity);
+
+        // then
+        assertThat(result).isFalse();
+        
+        // 재고가 변경되지 않았는지 확인
+        Optional<LoadProductPort.ProductInfo> productInfo = productPersistenceAdapter.loadProductById(productId);
+        assertThat(productInfo).isPresent();
+        assertThat(productInfo.get().getStock()).isEqualTo(100); // 원래 재고 유지
+    }
+
+    @Test
+    @DisplayName("재고 차감 - 존재하지 않는 상품")
+    void deductStock_ProductNotFound() {
+        // given
+        Long productId = 999L;
+        Integer quantity = 10;
+
+        // when
+        boolean result = productPersistenceAdapter.deductStock(productId, quantity);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("재고 복구 - 정상 복구")
+    void restoreStock_Success() {
+        // given
+        Long productId = 1L;
+        Integer quantity = 10;
+        
+        // 먼저 재고 차감
+        productPersistenceAdapter.deductStock(productId, quantity);
+        
+        // 재고 차감 확인
+        Optional<LoadProductPort.ProductInfo> beforeRestore = productPersistenceAdapter.loadProductById(productId);
+        assertThat(beforeRestore).isPresent();
+        assertThat(beforeRestore.get().getStock()).isEqualTo(90);
+
+        // when
+        boolean result = productPersistenceAdapter.restoreStock(productId, quantity);
+
+        // then
+        assertThat(result).isTrue();
+        
+        // 재고가 실제로 복구되었는지 확인
+        Optional<LoadProductPort.ProductInfo> afterRestore = productPersistenceAdapter.loadProductById(productId);
+        assertThat(afterRestore).isPresent();
+        assertThat(afterRestore.get().getStock()).isEqualTo(100); // 90 + 10
+    }
+
+    @Test
+    @DisplayName("재고 복구 - 존재하지 않는 상품")
+    void restoreStock_ProductNotFound() {
+        // given
+        Long productId = 999L;
+        Integer quantity = 10;
+
+        // when
+        boolean result = productPersistenceAdapter.restoreStock(productId, quantity);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("재고 복구 - 복구 후 재고 증가 확인")
+    void restoreStock_StockIncreased() {
+        // given
+        Long productId = 1L;
+        Integer originalStock = 100;
+        Integer deductQuantity = 30;
+        Integer restoreQuantity = 30;
+        
+        // 재고 차감
+        productPersistenceAdapter.deductStock(productId, deductQuantity);
+        
+        // 재고 차감 확인
+        Optional<LoadProductPort.ProductInfo> afterDeduct = productPersistenceAdapter.loadProductById(productId);
+        assertThat(afterDeduct).isPresent();
+        assertThat(afterDeduct.get().getStock()).isEqualTo(originalStock - deductQuantity);
+
+        // when
+        boolean result = productPersistenceAdapter.restoreStock(productId, restoreQuantity);
+
+        // then
+        assertThat(result).isTrue();
+        
+        // 재고가 원래대로 복구되었는지 확인
+        Optional<LoadProductPort.ProductInfo> afterRestore = productPersistenceAdapter.loadProductById(productId);
+        assertThat(afterRestore).isPresent();
+        assertThat(afterRestore.get().getStock()).isEqualTo(originalStock);
+    }
+
+    @Test
+    @DisplayName("재고 복구 - 부분 복구")
+    void restoreStock_PartialRestore() {
+        // given
+        Long productId = 1L;
+        Integer originalStock = 100;
+        Integer deductQuantity = 50;
+        Integer restoreQuantity = 20; // 일부만 복구
+        
+        // 재고 차감
+        productPersistenceAdapter.deductStock(productId, deductQuantity);
+        
+        // 재고 차감 확인
+        Optional<LoadProductPort.ProductInfo> afterDeduct = productPersistenceAdapter.loadProductById(productId);
+        assertThat(afterDeduct).isPresent();
+        assertThat(afterDeduct.get().getStock()).isEqualTo(originalStock - deductQuantity);
+
+        // when
+        boolean result = productPersistenceAdapter.restoreStock(productId, restoreQuantity);
+
+        // then
+        assertThat(result).isTrue();
+        
+        // 부분 복구 확인
+        Optional<LoadProductPort.ProductInfo> afterRestore = productPersistenceAdapter.loadProductById(productId);
+        assertThat(afterRestore).isPresent();
+        assertThat(afterRestore.get().getStock()).isEqualTo(originalStock - deductQuantity + restoreQuantity);
+    }
+
+    @Test
+    @DisplayName("재고 복구 - 복구 후 재고 초과 가능")
+    void restoreStock_CanExceedOriginalStock() {
+        // given
+        Long productId = 1L;
+        Integer originalStock = 100;
+        Integer deductQuantity = 30;
+        Integer restoreQuantity = 50; // 원래 재고보다 많이 복구
+        
+        // 재고 차감
+        productPersistenceAdapter.deductStock(productId, deductQuantity);
+        
+        // 재고 차감 확인
+        Optional<LoadProductPort.ProductInfo> afterDeduct = productPersistenceAdapter.loadProductById(productId);
+        assertThat(afterDeduct).isPresent();
+        assertThat(afterDeduct.get().getStock()).isEqualTo(originalStock - deductQuantity);
+
+        // when
+        boolean result = productPersistenceAdapter.restoreStock(productId, restoreQuantity);
+
+        // then
+        assertThat(result).isTrue();
+        
+        // 재고가 초과되어도 복구 가능한지 확인
+        Optional<LoadProductPort.ProductInfo> afterRestore = productPersistenceAdapter.loadProductById(productId);
+        assertThat(afterRestore).isPresent();
+        assertThat(afterRestore.get().getStock()).isEqualTo(originalStock - deductQuantity + restoreQuantity);
+        assertThat(afterRestore.get().getStock()).isGreaterThan(originalStock);
+    }
+
+    @Test
+    @DisplayName("재고 차감 후 복구 - 전체 사이클 테스트")
+    void deductAndRestoreStock_FullCycle() {
+        // given
+        Long productId = 1L;
+        Integer originalStock = 100;
+        Integer quantity = 25;
+        
+        // 초기 재고 확인
+        Optional<LoadProductPort.ProductInfo> initial = productPersistenceAdapter.loadProductById(productId);
+        assertThat(initial).isPresent();
+        assertThat(initial.get().getStock()).isEqualTo(originalStock);
+
+        // 1단계: 재고 차감
+        boolean deductResult = productPersistenceAdapter.deductStock(productId, quantity);
+        assertThat(deductResult).isTrue();
+        
+        Optional<LoadProductPort.ProductInfo> afterDeduct = productPersistenceAdapter.loadProductById(productId);
+        assertThat(afterDeduct).isPresent();
+        assertThat(afterDeduct.get().getStock()).isEqualTo(originalStock - quantity);
+
+        // 2단계: 재고 복구
+        boolean restoreResult = productPersistenceAdapter.restoreStock(productId, quantity);
+        assertThat(restoreResult).isTrue();
+        
+        Optional<LoadProductPort.ProductInfo> afterRestore = productPersistenceAdapter.loadProductById(productId);
+        assertThat(afterRestore).isPresent();
+        assertThat(afterRestore.get().getStock()).isEqualTo(originalStock);
+
+        // 3단계: 최종 확인
+        assertThat(afterRestore.get().getStock()).isEqualTo(initial.get().getStock());
+    }
+} 

--- a/src/test/java/kr/hhplus/be/server/order/application/facade/OrderFacadeTest.java
+++ b/src/test/java/kr/hhplus/be/server/order/application/facade/OrderFacadeTest.java
@@ -20,9 +20,10 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -328,5 +329,306 @@ class OrderFacadeTest {
         verify(useCouponUseCase).useCoupon(any(UseCouponUseCase.UseCouponCommand.class));
         verify(deductBalancePort, never()).deductBalance(any(), any());
         verify(saveOrderPort, never()).saveOrder(any());
+    }
+
+    @Test
+    @DisplayName("주문 생성 성공 - 재고 복구 불필요")
+    void createOrder_Success_NoStockRestore() {
+        // given
+        Long userId = 1L;
+        Long productId = 1L;
+        Integer quantity = 2;
+        BigDecimal productPrice = BigDecimal.valueOf(10000);
+        
+        CreateOrderUseCase.CreateOrderCommand command = new CreateOrderUseCase.CreateOrderCommand(
+                userId,
+                List.of(new CreateOrderUseCase.OrderItemCommand(productId, quantity)),
+                null // 쿠폰 없음
+        );
+        
+        // Mock 설정
+        when(loadUserPort.existsById(userId)).thenReturn(true);
+        when(loadProductPort.loadProductById(productId))
+                .thenReturn(Optional.of(new LoadProductPort.ProductInfo(productId, "테스트 상품", productPrice, 100)));
+        when(updateProductStockPort.deductStock(productId, quantity)).thenReturn(true);
+        when(deductBalancePort.deductBalance(userId, productPrice.multiply(BigDecimal.valueOf(quantity))))
+                .thenReturn(true);
+        
+        Order mockOrder = new Order(userId, List.of(), productPrice.multiply(BigDecimal.valueOf(quantity)), null);
+        mockOrder.setId(1L);
+        when(saveOrderPort.saveOrder(any(Order.class))).thenReturn(mockOrder);
+
+        // when
+        CreateOrderUseCase.CreateOrderResult result = orderFacade.createOrder(command);
+
+        // then
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getOrderId()).isEqualTo(1L);
+        
+        // 재고 복구가 호출되지 않았는지 확인
+        verify(updateProductStockPort, never()).restoreStock(anyLong(), anyInt());
+    }
+
+    @Test
+    @DisplayName("쿠폰 할인 실패 시 재고 복구")
+    void createOrder_CouponDiscountFailure_StockRestored() {
+        // given
+        Long userId = 1L;
+        Long productId = 1L;
+        Long userCouponId = 1L;
+        Integer quantity = 2;
+        BigDecimal productPrice = BigDecimal.valueOf(10000);
+        
+        CreateOrderUseCase.CreateOrderCommand command = new CreateOrderUseCase.CreateOrderCommand(
+                userId,
+                List.of(new CreateOrderUseCase.OrderItemCommand(productId, quantity)),
+                userCouponId
+        );
+        
+        // Mock 설정
+        when(loadUserPort.existsById(userId)).thenReturn(true);
+        when(loadProductPort.loadProductById(productId))
+                .thenReturn(Optional.of(new LoadProductPort.ProductInfo(productId, "테스트 상품", productPrice, 100)));
+        when(updateProductStockPort.deductStock(productId, quantity)).thenReturn(true);
+        
+        // 쿠폰 사용 실패 시뮬레이션
+        when(useCouponUseCase.useCoupon(any(UseCouponUseCase.UseCouponCommand.class)))
+                .thenReturn(UseCouponUseCase.UseCouponResult.failure("쿠폰을 찾을 수 없습니다."));
+
+        // when
+        CreateOrderUseCase.CreateOrderResult result = orderFacade.createOrder(command);
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrorMessage()).contains("쿠폰을 찾을 수 없습니다.");
+        
+        // 재고 복구가 호출되었는지 확인
+        verify(updateProductStockPort).restoreStock(productId, quantity);
+        
+        // 잔액 차감이 호출되지 않았는지 확인
+        verify(deductBalancePort, never()).deductBalance(anyLong(), any(BigDecimal.class));
+    }
+
+    @Test
+    @DisplayName("잔액 부족 시 재고 복구")
+    void createOrder_InsufficientBalance_StockRestored() {
+        // given
+        Long userId = 1L;
+        Long productId = 1L;
+        Integer quantity = 2;
+        BigDecimal productPrice = BigDecimal.valueOf(10000);
+        
+        CreateOrderUseCase.CreateOrderCommand command = new CreateOrderUseCase.CreateOrderCommand(
+                userId,
+                List.of(new CreateOrderUseCase.OrderItemCommand(productId, quantity)),
+                null // 쿠폰 없음
+        );
+        
+        // Mock 설정
+        when(loadUserPort.existsById(userId)).thenReturn(true);
+        when(loadProductPort.loadProductById(productId))
+                .thenReturn(Optional.of(new LoadProductPort.ProductInfo(productId, "테스트 상품", productPrice, 100)));
+        when(updateProductStockPort.deductStock(productId, quantity)).thenReturn(true);
+        
+        // 잔액 부족 시뮬레이션
+        when(deductBalancePort.deductBalance(userId, productPrice.multiply(BigDecimal.valueOf(quantity))))
+                .thenReturn(false);
+
+        // when
+        CreateOrderUseCase.CreateOrderResult result = orderFacade.createOrder(command);
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrorMessage()).contains("잔액이 부족합니다.");
+        
+        // 재고 복구가 호출되었는지 확인
+        verify(updateProductStockPort).restoreStock(productId, quantity);
+        
+        // 주문 저장이 호출되지 않았는지 확인
+        verify(saveOrderPort, never()).saveOrder(any(Order.class));
+    }
+
+    @Test
+    @DisplayName("주문 저장 실패 시 재고 복구")
+    void createOrder_OrderSaveFailure_StockRestored() {
+        // given
+        Long userId = 1L;
+        Long productId = 1L;
+        Integer quantity = 2;
+        BigDecimal productPrice = BigDecimal.valueOf(10000);
+        
+        CreateOrderUseCase.CreateOrderCommand command = new CreateOrderUseCase.CreateOrderCommand(
+                userId,
+                List.of(new CreateOrderUseCase.OrderItemCommand(productId, quantity)),
+                null // 쿠폰 없음
+        );
+        
+        // Mock 설정
+        when(loadUserPort.existsById(userId)).thenReturn(true);
+        when(loadProductPort.loadProductById(productId))
+                .thenReturn(Optional.of(new LoadProductPort.ProductInfo(productId, "테스트 상품", productPrice, 100)));
+        when(updateProductStockPort.deductStock(productId, quantity)).thenReturn(true);
+        when(deductBalancePort.deductBalance(userId, productPrice.multiply(BigDecimal.valueOf(quantity))))
+                .thenReturn(true);
+        
+        // 주문 저장 실패 시뮬레이션
+        when(saveOrderPort.saveOrder(any(Order.class)))
+                .thenThrow(new RuntimeException("데이터베이스 연결 오류"));
+
+        // when
+        CreateOrderUseCase.CreateOrderResult result = orderFacade.createOrder(command);
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrorMessage()).contains("주문 생성 중 오류가 발생했습니다");
+        assertThat(result.getErrorMessage()).contains("데이터베이스 연결 오류");
+        
+        // 재고 복구가 호출되었는지 확인
+        verify(updateProductStockPort).restoreStock(productId, quantity);
+    }
+
+    @Test
+    @DisplayName("여러 상품 주문 시 일부 실패로 재고 복구")
+    void createOrder_MultipleProducts_PartialFailure_StockRestored() {
+        // given
+        Long userId = 1L;
+        Long productId1 = 1L;
+        Long productId2 = 2L;
+        Integer quantity1 = 2;
+        Integer quantity2 = 3;
+        BigDecimal productPrice1 = BigDecimal.valueOf(10000);
+        BigDecimal productPrice2 = BigDecimal.valueOf(15000);
+        
+        CreateOrderUseCase.CreateOrderCommand command = new CreateOrderUseCase.CreateOrderCommand(
+                userId,
+                List.of(
+                        new CreateOrderUseCase.OrderItemCommand(productId1, quantity1),
+                        new CreateOrderUseCase.OrderItemCommand(productId2, quantity2)
+                ),
+                null // 쿠폰 없음
+        );
+        
+        // Mock 설정
+        when(loadUserPort.existsById(userId)).thenReturn(true);
+        when(loadProductPort.loadProductById(productId1))
+                .thenReturn(Optional.of(new LoadProductPort.ProductInfo(productId1, "테스트 상품 1", productPrice1, 100)));
+        when(loadProductPort.loadProductById(productId2))
+                .thenReturn(Optional.of(new LoadProductPort.ProductInfo(productId2, "테스트 상품 2", productPrice2, 100)));
+        when(updateProductStockPort.deductStock(productId1, quantity1)).thenReturn(true);
+        when(updateProductStockPort.deductStock(productId2, quantity2)).thenReturn(true);
+        
+        // 잔액 부족 시뮬레이션
+        when(deductBalancePort.deductBalance(eq(userId), any(BigDecimal.class)))
+                .thenReturn(false);
+
+        // when
+        CreateOrderUseCase.CreateOrderResult result = orderFacade.createOrder(command);
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrorMessage()).contains("잔액이 부족합니다.");
+        
+        // 두 상품 모두 재고 복구가 호출되었는지 확인
+        verify(updateProductStockPort).restoreStock(productId1, quantity1);
+        verify(updateProductStockPort).restoreStock(productId2, quantity2);
+    }
+
+    @Test
+    @DisplayName("재고 복구 실패 시 로그 기록")
+    void createOrder_StockRestoreFailure_LogsError() {
+        // given
+        Long userId = 1L;
+        Long productId = 1L;
+        Integer quantity = 2;
+        BigDecimal productPrice = BigDecimal.valueOf(10000);
+        
+        CreateOrderUseCase.CreateOrderCommand command = new CreateOrderUseCase.CreateOrderCommand(
+                userId,
+                List.of(new CreateOrderUseCase.OrderItemCommand(productId, quantity)),
+                null // 쿠폰 없음
+        );
+        
+        // Mock 설정
+        when(loadUserPort.existsById(userId)).thenReturn(true);
+        when(loadProductPort.loadProductById(productId))
+                .thenReturn(Optional.of(new LoadProductPort.ProductInfo(productId, "테스트 상품", productPrice, 100)));
+        when(updateProductStockPort.deductStock(productId, quantity)).thenReturn(true);
+        
+        // 잔액 부족 시뮬레이션
+        when(deductBalancePort.deductBalance(userId, productPrice.multiply(BigDecimal.valueOf(quantity))))
+                .thenReturn(false);
+        
+        // 재고 복구 실패 시뮬레이션
+        when(updateProductStockPort.restoreStock(productId, quantity))
+                .thenThrow(new RuntimeException("재고 복구 실패"));
+
+        // when
+        CreateOrderUseCase.CreateOrderResult result = orderFacade.createOrder(command);
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrorMessage()).contains("잔액이 부족합니다.");
+        
+        // 재고 복구가 호출되었는지 확인
+        verify(updateProductStockPort).restoreStock(productId, quantity);
+    }
+
+    @Test
+    @DisplayName("주문 검증 실패 시 재고 복구 불필요")
+    void createOrder_ValidationFailure_NoStockRestore() {
+        // given
+        Long userId = 999L; // 존재하지 않는 사용자
+        
+        CreateOrderUseCase.CreateOrderCommand command = new CreateOrderUseCase.CreateOrderCommand(
+                userId,
+                List.of(new CreateOrderUseCase.OrderItemCommand(1L, 2)),
+                null
+        );
+        
+        // Mock 설정
+        when(loadUserPort.existsById(userId)).thenReturn(false);
+
+        // when
+        CreateOrderUseCase.CreateOrderResult result = orderFacade.createOrder(command);
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrorMessage()).contains("사용자를 찾을 수 없습니다");
+        
+        // 재고 차감이나 복구가 호출되지 않았는지 확인
+        verify(updateProductStockPort, never()).deductStock(anyLong(), anyInt());
+        verify(updateProductStockPort, never()).restoreStock(anyLong(), anyInt());
+    }
+
+    @Test
+    @DisplayName("재고 부족 시 재고 복구 불필요")
+    void createOrder_InsufficientStock_NoStockRestore() {
+        // given
+        Long userId = 1L;
+        Long productId = 1L;
+        Integer quantity = 200; // 재고보다 많은 수량
+        BigDecimal productPrice = BigDecimal.valueOf(10000);
+        
+        CreateOrderUseCase.CreateOrderCommand command = new CreateOrderUseCase.CreateOrderCommand(
+                userId,
+                List.of(new CreateOrderUseCase.OrderItemCommand(productId, quantity)),
+                null
+        );
+        
+        // Mock 설정
+        when(loadUserPort.existsById(userId)).thenReturn(true);
+        when(loadProductPort.loadProductById(productId))
+                .thenReturn(Optional.of(new LoadProductPort.ProductInfo(productId, "테스트 상품", productPrice, 100)));
+
+        // when
+        CreateOrderUseCase.CreateOrderResult result = orderFacade.createOrder(command);
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrorMessage()).contains("재고가 부족합니다: 100");
+        
+        // 재고 차감이나 복구가 호출되지 않았는지 확인 (재고 확인 단계에서 실패했으므로)
+        verify(updateProductStockPort, never()).deductStock(anyLong(), anyInt());
+        verify(updateProductStockPort, never()).restoreStock(anyLong(), anyInt());
     }
 } 


### PR DESCRIPTION
## **커밋 링크**
- 선착순 쿠폰 발급 기능 구현 및 단위테스트 추가 : [63054](https://github.com/yuni02/hhplus-ecommerce/commit/6305441cb5c619f50ba82e490aa9ee090a83a67a)
- 결제 실패시 재고 복구 기능 구현 및 단테 추가 : [4c6ec](https://github.com/yuni02/hhplus-ecommerce/commit/4c6ecbf6776b51266e691f488203577eff8ae3ac)
---
## 리뷰 포인트
-  ReentrantLock을 사용한 쿠폰별 독립 락 방식이 실제 운영 환경에서 적절한지, 그리고 데이터베이스 기반으로 전환할 때 어떤 방식이 더 효율적인지 궁금합니다. (쿠폰별 락 vs 전체 락의 성능 차이)
- 트랜잭션 롤백만으로는 부족하다고 판단하여 명시적 재고 복구 로직을 추가했는데, 이 방식이 Clean Architecture 원칙에 부합하는지, 그리고 더 나은 대안이 있는지 궁금합니다.

---
### **핵심 체크리스트** :white_check_mark:

#### :one: 아키텍처 설계 (3개)
- [x] 선택한 아키텍처 패턴이 일관되게 적용되었는가?
- [x] 계층 간 의존성이 단방향으로 흐르는가? (순환참조 X)
- [x] README에 아키텍처 설명이 있는가?

#### :two: 핵심 구현 (3개)
- [x] 비즈니스 로직이 적절한 계층에 위치하는가?
- [x] 각 시나리오의 핵심 기능이 동작하는가?
- [x] 외부 기술(DB, HTTP)로부터 비즈니스 로직이 분리되었는가?

#### :three: 테스트 (2개)
- [x] 핵심 비즈니스 로직에 대한 단위 테스트가 있는가?
- [x] 테스트에서 Mock/Stub을 활용하여 의존성을 격리했는가?

---
### **구현 완료 기능** :pencil:

#### STEP05
- [x] **E-commerce**: 상품조회 + 주문/결제 + 포인트

#### STEP06
- [x] **E-commerce**: 선착순 쿠폰 + 재고 동시성 + 결제 실패 복구

---
### **간단 회고** (3줄 이내)
- **잘한 점**: 
  - 기존 아키텍쳐의 일관성을 유지하면서 코드 개선함.
  - 역시나 구축한 아키텍쳐는 단위테스트 작성에 용이하여 편함.  
- **어려운 점**: 
  - 계층이 많이 나눠져있다보니 이 계층에서 이 로직을 담당하게 하게 맞는건지 헷갈림. ex) facade 레이어에서 transactional 하는게 맞는건가?
- **다음 시도**:
  - 항상 항해99는 새로운 지식 습득과 동시에 구현을 같이 하다보니 버거워서 조금더 시간을 갖고 아키텍쳐를 설계해보고 싶음.

